### PR TITLE
The testNetwork() function should take only one param

### DIFF
--- a/sample/src/js/index.js
+++ b/sample/src/js/index.js
@@ -4,7 +4,7 @@ import * as ConnectivityUI from './connectivity-ui.js';
 import otNetworkTestOptions from './config.js';
 var otNetworkTest = new OTNetworkTest(OT, otNetworkTestOptions);
 document.getElementById('connectivity_status_container').style.display = 'block';
-otNetworkTest.testConnectivity(null, function(error, results) {
+otNetworkTest.testConnectivity(function(error, results) {
   ConnectivityUI.displayTestConnectivityResults(error, results);
   testQuality();
 });

--- a/src/NetworkTest/index.ts
+++ b/src/NetworkTest/index.ts
@@ -88,7 +88,6 @@ export default class NetworkTest {
    * opentok-network-test-js project for details.
    */
   testConnectivity(
-    deviceOptions?: DeviceOptions,
     onComplete?: CompletionCallback<any>): Promise<ConnectivityTestResults> {
     this.otLogging.logEvent({ action: 'testConnectivity', variation: 'Attempt' });
     this.validateCallbacks('testConnectivity', null, onComplete);

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -40,14 +40,7 @@ type TestQualityResults = {
   },
 }
 
-
-type DeviceId = string;
 type InputDeviceType = 'audioInput' | 'videoInput';
-type DeviceOptions = {
-  audioDevice?: DeviceId,
-  videoDevice?: DeviceId
-}
-
 
 /**
  * Quality Test


### PR DESCRIPTION
It should take a callback parameter. The deviceOptions parameter is
unused.