### PR TITLE
Add separate check for api server connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-network-test-js",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "Precall network test for applications using the OpenTok platform.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/NetworkTest/testConnectivity/errors/index.ts
+++ b/src/NetworkTest/testConnectivity/errors/index.ts
@@ -21,6 +21,19 @@ export class ConnectivityError extends NetworkTestError {
 }
 
 /**
+ * API Connectivity Error
+ */
+export class APIConnectivityError extends ConnectivityError {
+  name: string;
+  constructor() {
+    const message = 'Failed to connect to OpenTOK API Server';
+    super(message);
+    Object.setPrototypeOf(this, APIConnectivityError.prototype);
+    this.name = this.constructor.name;
+  }
+}
+
+/**
  * Session Errors
  */
 export class ConnectToSessionError extends ConnectivityError {
@@ -65,19 +78,19 @@ export class MediaDeviceError extends ConnectivityError {
   }
 }
 
-export class FailedToObtainMediaDevices extends ConnectivityError {
+export class FailedToObtainMediaDevices extends MediaDeviceError {
   constructor() {
     super('Failed to obtain media devices from OT.getDevices()');
   }
 }
 
-export class NoVideoCaptureDevicesError extends ConnectivityError {
+export class NoVideoCaptureDevicesError extends MediaDeviceError {
   constructor() {
     super('This browser has no video capture devices');
   }
 }
 
-export class NoAudioCaptureDevicesError extends ConnectivityError {
+export class NoAudioCaptureDevicesError extends MediaDeviceError {
   constructor() {
     super('This browser has no audio capture devices.');
   }

--- a/src/NetworkTest/testConnectivity/errors/mapping.ts
+++ b/src/NetworkTest/testConnectivity/errors/mapping.ts
@@ -10,7 +10,8 @@
 import { ConnectivityError } from './index';
 
 export enum FailureType {
-  ConnectToSessionError = 'api',
+  APIConnectivityError = 'api',
+  ConnectToSessionError = 'media',
   MediaDeviceError = 'OpenTok.js',
   PublishToSessionError = 'media',
   SubscribeToSessionError = 'media',
@@ -27,6 +28,8 @@ const mapErrorToCase = (error: ConnectivityError): FailureCase => {
 
   const getType = (): FailureType => {
     switch (error.name) {
+      case 'APIConnectivityError':
+        return FailureType[error.name];
       case 'ConnectToSessionError':
         return FailureType[error.name];
       case 'MediaDeviceError':

--- a/src/NetworkTest/testConnectivity/index.ts
+++ b/src/NetworkTest/testConnectivity/index.ts
@@ -51,7 +51,7 @@ function connectToAPIServer(
 function connectToSession({ session, token }: ConnectToAPIServerResults): Promise<OT.Session> {
   return new Promise((resolve, reject) => {
     session.connect(token, (error?: OT.OTError) => {
-      if (errorHasName(error, OTErrorType.AUTHENTICATION_ERROR)) {
+      if (errorHasName(error, OTErrorType.OT_AUTHENTICATION_ERROR)) {
         reject(new e.ConnectToSessionTokenError());
       } else if (errorHasName(error, OTErrorType.INVALID_SESSION_ID)) {
         reject(new e.ConnectToSessionSessionIdError());

--- a/src/NetworkTest/testConnectivity/index.ts
+++ b/src/NetworkTest/testConnectivity/index.ts
@@ -129,6 +129,9 @@ function checkPublishToSession(OT: OpenTok, session: OT.Session): Promise<Publis
     checkCreateLocalPublisher(OT)
       .then(({ publisher }: CreateLocalPublisherResults) => {
         session.publish(publisher, (error?: OT.OTError) => {
+          if (error) {
+            session.disconnect();
+          }
           if (errorHasName(error, OTErrorType.NOT_CONNECTED)) {
             reject(new e.PublishToSessionNotConnectedError());
           } else if (errorHasName(error, OTErrorType.UNABLE_TO_PUBLISH)) {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -11,6 +11,7 @@ interface OpenTok {
   initPublisher: (targetElement?: HTMLElement | string, properties?: OT.PublisherProperties, callback?: (error?: OT.OTError) => void) => OT.Publisher;
   getDevices(callback: (error: OT.OTError | undefined, devices?: OT.Device[]) => void): void;
   properties: OT.Properties
+  SessionInfo: OT.SessionInfo
 }
 
 type SessionCredentials = {

--- a/src/types/opentok.d.ts
+++ b/src/types/opentok.d.ts
@@ -331,6 +331,10 @@ declare module OT {
     timestamp: number;
   }
 
+  export class SessionInfo {
+    get: (sessionId: string, token: string, connectionId: string) => Promise<void>
+  }
+
   export class Subscriber extends OTEventEmitter<{
     audioLevelUpdated: Event<'audioLevelUpdated', Subscriber> & {
       audioLevel: number

--- a/test/NetworkTest.spec.ts
+++ b/test/NetworkTest.spec.ts
@@ -93,7 +93,7 @@ describe('Network Test', () => {
           expect(results.success).toBe(false);
           expect(results.failedTests).toBeInstanceOf(Array);
           const { type, error } = head(results.failedTests);
-          expect(type).toBe('api');
+          expect(type).toBe('media');
           expect(error).toBeInstanceOf(ConnectToSessionError);
         };
 


### PR DESCRIPTION
If the API Server check is successful, any additional failures must be due to an issue related to media servers.