### PR TITLE
ECO-1668 - Update vulnerable dependency (marked)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-network-test-js",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4413,8 +4413,8 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
       "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
       "dev": true
     },
@@ -6147,7 +6147,7 @@
         "handlebars": "4.0.11",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
-        "marked": "0.3.6",
+        "marked": "0.3.12",
         "minimatch": "3.0.4",
         "progress": "2.0.0",
         "shelljs": "0.7.8",


### PR DESCRIPTION
See the release notes for marked v0.3.9:
https://github.com/chjj/marked/releases.