### PR TITLE
Append subscriber to target element

### DIFF
--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -133,11 +133,14 @@ function publishAndSubscribe(OT: OpenTok) {
           });
           publisher.on('streamCreated', (event: StreamCreatedEvent) => {
             const subscriber =
-              session.subscribe(event.stream, containerDiv, { testNetwork: true }, (subscribeError?: OT.OTError) => {
-                return subscribeError ?
-                  reject(new e.SubscribeToSessionError(subscribeError.message)) :
-                  resolve(subscriber);
-              });
+              session.subscribe(event.stream,
+                containerDiv,
+                { testNetwork: true, insertMode: 'append' },
+                (subscribeError?: OT.OTError) => {
+                  return subscribeError ?
+                    reject(new e.SubscribeToSessionError(subscribeError.message)) :
+                    resolve(subscriber);
+                });
           });
         })
         .catch(reject);


### PR DESCRIPTION
The tokbox documentation doesn't mention what is the default `insertMode`, but without `insertMode: append` it was inserting the subscribers after the target element of 1px, screwing up my application's layout.

This also poses the question whether they need to be inserted in the UI at all. Because even the 1px is visible in my app. Because even. What about making it a `position: fixed` and moving it off-screen ?
At least in Chrome the test works fine if I don't give a `targetElement`, but instead add `insertDefaultUI: false` to both subscriber and publisher options.