### PR TITLE
remove node as target

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,6 @@ module.exports = {
   resolve: {
     extensions: ['.ts', '.js', '.json']
   },
-  target: 'node',
   output: {
     filename: 'index.js',
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
This is a fix for #61, removing this allows the output of the webpack bundle to work within a react project. However, I am not a webpack expert, so I'm not sure how this could impact other use cases.