### PR TITLE
Add Facebook Webview detection.

### DIFF
--- a/src/NetworkTest/testQuality/helpers/isSupportedBrowser.ts
+++ b/src/NetworkTest/testQuality/helpers/isSupportedBrowser.ts
@@ -25,7 +25,10 @@ function detectBrowser(): Browser {
   }
   if (get('webkitGetUserMedia', navigator)) {
     // Chrome, Chromium, Webview, Opera, all use the chrome shim for now
-    if (window.hasOwnProperty('webkitRTCPeerConnection')) {
+    if (window.hasOwnProperty('webkitRTCPeerConnection') &&
+      // Facebook has an RTC property, but fails to connect
+      !navigator.userAgent.match(/;fbav\/([\d.]+);/i)
+    ) {
       return 'Chrome';
     }
     if (navigator.userAgent.match(/Version\/(\d+).(\d+)/)) {


### PR DESCRIPTION
Facebook Webview is currently being detected as Chrome, but does not support WebRTC. This change reflects the lack of support.