### PR TITLE
Add the options audioSource and videoSource for the quality test

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/webrtc": "0.0.22",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
+    "babel-preset-env": "^1.7.0",
     "dotenv": "^4.0.0",
     "fs-extra": "^4.0.3",
     "jasmine": "^2.99.0",

--- a/src/NetworkTest/index.ts
+++ b/src/NetworkTest/index.ts
@@ -31,6 +31,8 @@ import OTKAnalytics = require('opentok-solutions-logging');
 export interface NetworkTestOptions {
   audioOnly?: boolean;
   timeout?: number;
+  audioSource?: string;
+  videoSource?: string;
 }
 
 export default class NetworkTest {
@@ -106,7 +108,6 @@ export default class NetworkTest {
         throw new InvalidOnUpdateCallback();
       }
     }
-
     return testQuality(
       this.OT, this.credentials, this.otLogging, this.options, updateCallback);
   }

--- a/src/NetworkTest/testConnectivity/index.ts
+++ b/src/NetworkTest/testConnectivity/index.ts
@@ -127,6 +127,12 @@ function checkCreateLocalPublisher(
           insertMode: 'append',
           showControls: false,
         };
+        if (options && options.audioSource) {
+          publisherOptions.audioSource = options.audioSource
+        }
+        if (options && options.videoSource) {
+          publisherOptions.videoSource = options.videoSource
+        }
         if (options && options.audioOnly) {
           publisherOptions.videoSource = null;
         }
@@ -140,6 +146,7 @@ function checkCreateLocalPublisher(
           if (!error) {
             resolve({ publisher });
           } else {
+            console.error('OT.initPublisher', publisherOptions, error)
             reject(new e.FailedToCreateLocalPublisher());
           }
         });

--- a/src/NetworkTest/testConnectivity/index.ts
+++ b/src/NetworkTest/testConnectivity/index.ts
@@ -146,7 +146,6 @@ function checkCreateLocalPublisher(
           if (!error) {
             resolve({ publisher });
           } else {
-            console.error('OT.initPublisher', publisherOptions, error)
             reject(new e.FailedToCreateLocalPublisher());
           }
         });


### PR DESCRIPTION
The `NetworkTest` can receive the options `audioSource` and `videoSource` to be tested. Both, the `testConnectivity` and `testQuality` use those options to create the publisher stream. 

Usage:
```
new NetworkTest(OT, {
      apiKey,
      sessionId,
      token
}, {
      audioSource, // Microphone deviceID
      videoSource // Webcam deviceID
})

```