### PR TITLE
remove unused for subscriberMOS

### DIFF
--- a/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
+++ b/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
@@ -34,9 +34,6 @@ function calculateVideoScore(subscriber: OT.Subscriber, stats: OT.SubscriberStat
     return 1;
   }
 
-  const totalPackets = calculateTotalPackets('video', currentStats, lastStats);
-  const packetLoss = getPacketsLost(currentStats.video) - getPacketsLost(lastStats.video) / totalPackets;
-  const interval = currentStats.timestamp - lastStats.timestamp;
   const baseBitrate = calculateBitRate('video', currentStats, lastStats);
   const pixelCount = subscriber.stream.videoDimensions.width * subscriber.stream.videoDimensions.height;
   const targetBitrate = targetBitrateForPixelCount(pixelCount);
@@ -123,7 +120,6 @@ export default function subscriberMOS(
          * We know that we're receiving "faulty" stats when we see a negative
          * value for bytesReceived.
          */
-        const getPacketsLost = (ts: OT.TrackStats): number => getOr(0, 'packetsLost', ts);
         if (stats.audio.bytesReceived < 0 || getOr(1, 'video.bytesReceived', stats) < 0) {
           mosState.clearInterval();
           return callback(mosState);


### PR DESCRIPTION
- in `calculateVideoScore` function
  * remove `interval` as it's not being used at all, [ref](https://github.com/opentok/opentok-network-test-js/blob/v2.2.1/src/NetworkTest/testQuality/helpers/subscriberMOS.ts#L39)
  * `totalPackets` is being used in `packetLoss` but `packetLoss` is not being used, removed both of them 😱 [ref](https://github.com/opentok/opentok-network-test-js/blob/v2.2.1/src/NetworkTest/testQuality/helpers/subscriberMOS.ts#L37-L38)
- in `subscriberMOS` function
  * remove `getPacketsLost` as it has been defined earlier [ref](https://github.com/opentok/opentok-network-test-js/blob/v2.2.1/src/NetworkTest/testQuality/helpers/subscriberMOS.ts#L10)