### PR TITLE
Fix stop network test

### DIFF
--- a/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
+++ b/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
@@ -115,7 +115,7 @@ export default function subscriberMOS(
         }
 
         /**
-         * We occaisionally start to receive faulty stat during long-running
+         * We occasionally start to receive faulty stat during long-running
          * tests. If this occurs, let's end the test early and report the
          * results as they are, as we should have sufficient data to
          * calculate a score at this point.

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -274,7 +274,7 @@ function checkSubscriberQuality(
 
             const processResults = () => {
               const audioVideoResults: QualityTestResults = buildResults(builder);
-              if (!audioOnly && !isAudioQualityAcceptable(audioVideoResults)) {
+              if (!audioOnly && !isAudioQualityAcceptable(audioVideoResults) && !stopTestCalled) {
                 audioOnly = true;
                 checkSubscriberQuality(OT, session, credentials, options, onUpdate, true)
                   .then((results: QualityTestResults) => {

--- a/test/NetworkTest.spec.ts
+++ b/test/NetworkTest.spec.ts
@@ -400,8 +400,7 @@ describe('NetworkTest', () => {
         });
 
         const validateResults = (results: QualityTestResults) => {
-          const { mos, audio, video } = results;
-
+          const { audio, video } = results;
           expect(audio.bitrate).toEqual(jasmine.any(Number));
           expect(audio.supported).toEqual(jasmine.any(Boolean));
           expect(audio.reason || '').toEqual(jasmine.any(String));
@@ -422,7 +421,7 @@ describe('NetworkTest', () => {
           .then(validateResults)
           .catch(validateError)
           .finally(done);
-      }, 8000);
+      }, 10000);
 
       it('should return an error if the window.navigator is undefined', () => {
         spyOnProperty(window, 'navigator', 'get').and.returnValue(undefined);


### PR DESCRIPTION
**What is this PR doing?**
This PR adds a fix for when the stop method is called. Currently, when the stop method is invoked, there's a case in which a new test for audio only is executed. I've added a condition to validate if the stop method was invoked before starting with the extra audio only test.

It also increase the timeout for the test `should return valid test results or an error when there is no camera` from 8 secs to 10 secs since it was failing, at least locally.