### PR TITLE
Add session options and Proxy Url Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ The `OTNetworkTest()` constructor includes the following parameters:
         is enabled for your project. The default value is false. 
 	  * `iceConfig ` (Object) -- This feature is part of the configurable TURN add-on feature.
 
-  * `proxyServerUrl` (String) -- Set the URL of your proxy server when you 
-    initiate an OpenTok session in the OpenTok client SDKs. 
-    For more information, please check the 
+  * `proxyServerUrl` (String) -- (Optional) Set this to the proxy server URL 
+    you use in the OpenTok client SDKs (for example, when calling OT.setProxyUrl()
+    in OpenTok.js). For more information, please check the 
     [IP Proxy Documentation](https://tokbox.com/developer/guides/ip-proxy/).
 
   The `options` parameter is optional.

--- a/README.md
+++ b/README.md
@@ -235,11 +235,19 @@ The `OTNetworkTest()` constructor includes the following parameters:
     to grant permission to the correct device. Note that changing the video device may not
     influence the quality test score.
   
-  * `initSessionOptions` (Object) -- An object that includes optional options for initializing the session ([Session Options](https://tokbox.com/developer/sdks/js/reference/OT.html#initSession)). This object includes the following properties:
-	  * `ipWhitelist ` (Boolean) -- This is available as an add-on feature for **enterprise accounts**. Set this to true if IP white listing is enabled for your project. The default value is false. 
+  * `initSessionOptions` (Object) -- An object that includes optional options 
+    for initializing the session 
+    ([Session Options](https://tokbox.com/developer/sdks/js/reference/OT.html#initSession)). 
+    This object includes the following properties:
+	  * `ipWhitelist ` (Boolean) -- This is available as an add-on feature
+        for **enterprise accounts**. Set this to true if IP white listing 
+        is enabled for your project. The default value is false. 
 	  * `iceConfig ` (Object) -- This feature is part of the configurable TURN add-on feature.
 
-  * `proxyServerUrl` (String) -- Set the URL of your proxy server when you initiate an OpenTok session in the OpenTok client SDKs. For more information, please check the [IP Proxy Documentation](https://tokbox.com/developer/guides/ip-proxy/).
+  * `proxyServerUrl` (String) -- Set the URL of your proxy server when you 
+    initiate an OpenTok session in the OpenTok client SDKs. 
+    For more information, please check the 
+    [IP Proxy Documentation](https://tokbox.com/developer/guides/ip-proxy/).
 
   The `options` parameter is optional.
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ The `OTNetworkTest()` constructor includes the following parameters:
     will be used in the real OpenTok session. This way, the test prompts the end user
     to grant permission to the correct device. Note that changing the video device may not
     influence the quality test score.
+  
+  * `initSessionOptions` (Object) -- An object that includes optional options for initializing the session ([Session Options](https://tokbox.com/developer/sdks/js/reference/OT.html#initSession)). This object includes the following properties:
+	  * `ipWhitelist ` (Boolean) -- This is available as an add-on feature for **enterprise accounts**. Set this to true if IP white listing is enabled for your project. The default value is false. 
+	  * `iceConfig ` (Object) -- This feature is part of the configurable TURN add-on feature.
+
+  * `proxyServerUrl` (String) -- Set the URL of your proxy server when you initiate an OpenTok session in the OpenTok client SDKs. For more information, please check the [IP Proxy Documentation](https://tokbox.com/developer/guides/ip-proxy/).
 
   The `options` parameter is optional.
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The `OTNetworkTest()` constructor includes the following parameters:
 	  * `iceConfig ` (Object) -- This feature is part of the configurable TURN add-on feature.
 
   * `proxyServerUrl` (String) -- (Optional) Set this to the proxy server URL 
-    you use in the OpenTok client SDKs (for example, when calling OT.setProxyUrl()
+    you use in the OpenTok client SDKs (for example, when calling `OT.setProxyUrl()`
     in OpenTok.js). For more information, please check the 
     [IP Proxy Documentation](https://tokbox.com/developer/guides/ip-proxy/).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,9 +102,9 @@
       }
     },
     "@opentok/client": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@opentok/client/-/client-2.17.1.tgz",
-      "integrity": "sha512-yQMKMhCS43XDJDUlidjsu5mdLT31R+zvJT2I2DCQJ7753OZ4aYIqDauU7VHODXUmrkvt48Ex7OV7EHGcw1bm8w==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@opentok/client/-/client-2.17.5.tgz",
+      "integrity": "sha512-xpbwekUqnEmqs+aQ3yxeEI1h3UnpdDqt1gNcq+NzPdGwcC6yusVWkrgU3BMUgcyW3IxrDZRR3uD8d+YIkQ8zWQ==",
       "dev": true
     },
     "@types/expect.js": {
@@ -5123,9 +5123,9 @@
       }
     },
     "opentok-solutions-logging": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/opentok-solutions-logging/-/opentok-solutions-logging-1.0.15.tgz",
-      "integrity": "sha512-o8alNMf+A1Vd4oLFTP26F87qLm9xYokEi97QKR+n7+ZZfa/IlwrWM54msA65yyB+0YLbk7qHxNFfJ2ezGb+xOg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/opentok-solutions-logging/-/opentok-solutions-logging-1.1.0.tgz",
+      "integrity": "sha512-4D/l9d/1q7TLs17mm05tKsZCZhv0qZkF5P18u3ltlMnPIPkw5l+uq0rimIQ4AKvDM0XfNIV2R6bD39ThyL4/0A==",
       "requires": {
         "axios": "^0.19.0"
       }
@@ -7353,7 +7353,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7374,12 +7375,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7394,17 +7397,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7521,7 +7527,8 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7533,6 +7540,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7547,6 +7555,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -7554,12 +7563,14 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7578,6 +7589,7 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -7639,7 +7651,8 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -7667,7 +7680,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7679,6 +7693,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7756,7 +7771,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7792,6 +7808,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7811,6 +7828,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7854,12 +7872,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-network-test-js",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7312,8 +7312,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7334,14 +7333,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7356,20 +7353,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7486,8 +7480,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7499,7 +7492,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7514,7 +7506,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -7522,14 +7513,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7548,7 +7537,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7638,8 +7626,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7651,7 +7638,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7737,8 +7723,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7774,7 +7759,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7794,7 +7778,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7838,14 +7821,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7312,7 +7312,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7333,12 +7334,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7353,17 +7356,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7480,7 +7486,8 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7492,6 +7499,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7506,6 +7514,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -7513,12 +7522,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7537,6 +7548,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7626,7 +7638,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7638,6 +7651,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7723,7 +7737,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7759,6 +7774,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7778,6 +7794,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7821,12 +7838,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
   "homepage": "https://github.com/opentok/network-connectivity-js#readme",
   "dependencies": {
     "axios": "^0.19.0",
-    "opentok-solutions-logging": "^1.0.15",
+    "opentok-solutions-logging": "^1.1.0",
     "promise": "^8.0.1"
   },
   "devDependencies": {
-    "@opentok/client": "^2.16.1",
+    "@opentok/client": "^2.17.5",
     "@types/expect.js": "^0.3.29",
     "@types/jasmine": "^2.8.8",
     "@types/jasmine-matchers": "^0.2.30",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-network-test-js",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Precall network test for applications using the OpenTok platform.",
   "main": "dist/NetworkTest/index.js",
   "types": "dist/NetworkTest/index.d.ts",

--- a/sample/src/js/index.js
+++ b/sample/src/js/index.js
@@ -19,8 +19,7 @@ function startTest() {
     var timeout = timeoutSelect.options[timeoutSelect.selectedIndex].text * 1000;
     var options = {
         audioOnly: audioOnly,
-        timeout: timeout,
-        proxyServerUrl: 'https://ip-proxy.opentok.cse.vonage.com'
+        timeout: timeout
     };
     otNetworkTest = new NetworkTest(OT, sessionInfo, options);
     otNetworkTest.testConnectivity()

--- a/sample/src/js/index.js
+++ b/sample/src/js/index.js
@@ -7,38 +7,39 @@ let otNetworkTest;
 let audioOnly;
 
 const precallDiv = document.getElementById('precall');
-precallDiv.querySelector('#precall button').addEventListener('click', function() {
-  document.getElementById('connectivity_status_container').style.display = 'block';
-  precallDiv.style.display = 'none';
-  startTest();
+precallDiv.querySelector('#precall button').addEventListener('click', function () {
+    document.getElementById('connectivity_status_container').style.display = 'block';
+    precallDiv.style.display = 'none';
+    startTest();
 })
 
 function startTest() {
-  audioOnly = precallDiv.querySelector('#precall input').checked;
-  var timeoutSelect = precallDiv.querySelector('select');
-  var timeout = timeoutSelect.options[timeoutSelect.selectedIndex].text * 1000;
-  var options = {
-    audioOnly: audioOnly,
-    timeout: timeout
-  };
-  otNetworkTest = new NetworkTest(OT, sessionInfo, options);
-  otNetworkTest.testConnectivity()
-    .then(results => ConnectivityUI.displayTestConnectivityResults(results))
-    .then(testQuality);
+    audioOnly = precallDiv.querySelector('#precall input').checked;
+    var timeoutSelect = precallDiv.querySelector('select');
+    var timeout = timeoutSelect.options[timeoutSelect.selectedIndex].text * 1000;
+    var options = {
+        audioOnly: audioOnly,
+        timeout: timeout,
+        proxyServerUrl: 'https://ip-proxy.opentok.cse.vonage.com'
+    };
+    otNetworkTest = new NetworkTest(OT, sessionInfo, options);
+    otNetworkTest.testConnectivity()
+        .then(results => ConnectivityUI.displayTestConnectivityResults(results))
+        .then(testQuality);
 }
 
 function testQuality() {
-  createChart('audio');
-  createChart('video');
-  ConnectivityUI.init(audioOnly);
-  document.getElementById('stop_test').addEventListener('click', function stopTestListener() {
-    ConnectivityUI.hideStopButton();
-    otNetworkTest.stop();
-  });
-  otNetworkTest.testQuality(function updateCallback(stats) {
-    ConnectivityUI.checkToDisplayStopButton();
-    ConnectivityUI.graphIntermediateStats('audio', stats);
-    ConnectivityUI.graphIntermediateStats('video', stats);
-  }).then(results => ConnectivityUI.displayTestQualityResults(null, results))
-    .catch(error => ConnectivityUI.displayTestQualityResults(error));
+    createChart('audio');
+    createChart('video');
+    ConnectivityUI.init(audioOnly);
+    document.getElementById('stop_test').addEventListener('click', function stopTestListener() {
+        ConnectivityUI.hideStopButton();
+        otNetworkTest.stop();
+    });
+    otNetworkTest.testQuality(function updateCallback(stats) {
+        ConnectivityUI.checkToDisplayStopButton();
+        ConnectivityUI.graphIntermediateStats('audio', stats);
+        ConnectivityUI.graphIntermediateStats('video', stats);
+    }).then(results => ConnectivityUI.displayTestQualityResults(null, results))
+        .catch(error => ConnectivityUI.displayTestQualityResults(error));
 }

--- a/src/NetworkTest/index.ts
+++ b/src/NetworkTest/index.ts
@@ -33,6 +33,8 @@ export interface NetworkTestOptions {
   timeout?: number;
   audioSource?: string;
   videoSource?: string;
+  initSessionOptions?: OT.InitSessionOptions
+  proxyServerUrl?: string;
 }
 
 export default class NetworkTest {

--- a/src/NetworkTest/index.ts
+++ b/src/NetworkTest/index.ts
@@ -50,10 +50,12 @@ export default class NetworkTest {
   constructor(OT: OT.Client, credentials: OT.SessionCredentials, options?: NetworkTestOptions) {
     this.validateOT(OT);
     this.validateCredentials(credentials);
-    this.otLogging = this.startLoggingEngine(credentials.apiKey, credentials.sessionId);
+    const proxyServerUrl = this.validateProxyUrl(options)
+    this.otLogging = this.startLoggingEngine(credentials.apiKey, credentials.sessionId, proxyServerUrl);
     this.OT = OT;
     this.credentials = credentials;
     this.options = options;
+    this.setProxyUrl(proxyServerUrl)
   }
 
   private validateOT(OT: OT.Client) {
@@ -71,14 +73,29 @@ export default class NetworkTest {
     }
   }
 
-  private startLoggingEngine(apiKey: string, sessionId: string): OTKAnalytics {
+  private validateProxyUrl(options?: NetworkTestOptions): string {
+    if (!options || !options.proxyServerUrl) {
+      return '';
+    }
+    return options.proxyServerUrl;
+  }
+
+  private setProxyUrl(proxyServerUrl: string) {
+    if (this.OT.setProxyUrl && typeof this.OT.setProxyUrl === 'function' && proxyServerUrl) {
+      this.OT.setProxyUrl(proxyServerUrl);
+    }
+  }
+
+  private startLoggingEngine(apiKey: string, sessionId: string, proxyUrl: string): OTKAnalytics {
     return new OTKAnalytics({
       sessionId,
       partnerId: apiKey,
       source: window.location.href,
       clientVersion: 'js-network-test-' + version,
       name: 'opentok-network-test',
-      componentId: 'opentok-network-test',
+      componentId: 'opentok-network-test'
+    }, {
+      proxyUrl
     });
   }
 

--- a/src/NetworkTest/testConnectivity/index.ts
+++ b/src/NetworkTest/testConnectivity/index.ts
@@ -57,7 +57,10 @@ function connectToSession(
   options?: NetworkTestOptions
 ): Promise<OT.Session> {
   return new Promise((resolve, reject) => {
-    const sessionOptions = options?.initSessionOptions || {};
+    let sessionOptions: OT.InitSessionOptions = {};
+    if (options && options.initSessionOptions) {
+        sessionOptions = options.initSessionOptions
+    }
     if (options && options.proxyServerUrl) {
         if (OT.setProxyUrl && typeof OT.setProxyUrl === 'function'){
             OT.setProxyUrl(options.proxyServerUrl);

--- a/src/NetworkTest/testConnectivity/index.ts
+++ b/src/NetworkTest/testConnectivity/index.ts
@@ -264,8 +264,8 @@ function checkSubscribeToSession({ session, publisher }: PublishToSessionResults
  */
 function checkLoggingServer(OT: OT.Client, options?: NetworkTestOptions, input?: SubscribeToSessionResults): Promise<SubscribeToSessionResults> {
   return new Promise((resolve, reject) => {
-    const loggingUrl = 'hlg.tokbox.com/prod/logging/ClientEvent';
-    const url = options && options.proxyServerUrl && `${options.proxyServerUrl}/${loggingUrl}` || `https://${loggingUrl}`;
+    const loggingUrl = `${getOr('', 'properties.loggingURL', OT)}/logging/ClientEvent`; //https://hlg.tokbox.com/prod
+    const url = options && options.proxyServerUrl && `${options.proxyServerUrl}/${loggingUrl.replace('https://', '')}` || loggingUrl;
     const handleError = () => reject(new e.LoggingServerConnectionError());
 
     axios.post(url)

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -367,14 +367,12 @@ export function testQuality(
       .then(() => {
         let sessionOptions: OT.InitSessionOptions = {};
         if (options && options.initSessionOptions) {
-            sessionOptions = options.initSessionOptions
+          sessionOptions = options.initSessionOptions
         }
         if (options && options.proxyServerUrl) {
-            if (options && options.proxyServerUrl) {
-                if (!OT.hasOwnProperty('setProxyUrl')) { // Fallback for OT.version < 2.17.4
-                  sessionOptions.proxyUrl = options.proxyServerUrl; 
-                }
-            }
+          if (!OT.hasOwnProperty('setProxyUrl')) { // Fallback for OT.version < 2.17.4
+            sessionOptions.proxyUrl = options.proxyServerUrl;
+          }
         }
         const session = OT.initSession(credentials.apiKey, credentials.sessionId, sessionOptions);
         checkSubscriberQuality(OT, session, credentials, options, onUpdate)

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -329,7 +329,10 @@ export function testQuality(
 
     validateBrowser()
       .then(() => {
-        const sessionOptions = options?.initSessionOptions || {};
+        let sessionOptions: OT.InitSessionOptions = {};
+        if (options && options.initSessionOptions) {
+            sessionOptions = options.initSessionOptions
+        }
         if (options && options.proxyServerUrl) {
             if (OT.setProxyUrl && typeof OT.setProxyUrl === 'function'){
                 OT.setProxyUrl(options.proxyServerUrl);

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -370,10 +370,10 @@ export function testQuality(
             sessionOptions = options.initSessionOptions
         }
         if (options && options.proxyServerUrl) {
-            if (OT.setProxyUrl && typeof OT.setProxyUrl === 'function'){
-                OT.setProxyUrl(options.proxyServerUrl);
-            } else {
-                sessionOptions.proxyUrl = options.proxyServerUrl;
+            if (options && options.proxyServerUrl) {
+                if (!OT.hasOwnProperty('setProxyUrl')) { // Fallback for OT.version < 2.17.4
+                  sessionOptions.proxyUrl = options.proxyServerUrl; 
+                }
             }
         }
         const session = OT.initSession(credentials.apiKey, credentials.sessionId, sessionOptions);

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -329,7 +329,15 @@ export function testQuality(
 
     validateBrowser()
       .then(() => {
-        const session = OT.initSession(credentials.apiKey, credentials.sessionId);
+        const sessionOptions = options?.initSessionOptions || {};
+        if (options && options.proxyServerUrl) {
+            if (OT.setProxyUrl && typeof OT.setProxyUrl === 'function'){
+                OT.setProxyUrl(options.proxyServerUrl);
+            } else {
+                sessionOptions.proxyUrl = options.proxyServerUrl;
+            }
+        }
+        const session = OT.initSession(credentials.apiKey, credentials.sessionId, sessionOptions);
         checkSubscriberQuality(OT, session, credentials, options, onUpdate)
           .then(onSuccess)
           .catch(onError);

--- a/src/NetworkTest/types/opentok/index.ts
+++ b/src/NetworkTest/types/opentok/index.ts
@@ -48,6 +48,7 @@ export namespace OT {
     initSession(
       partnerId: string,
       sessionId: string,
+      options?: OTSession.initSessionOptions
     ): Session;
 
     registerScreenSharingExtension(
@@ -59,6 +60,8 @@ export namespace OT {
     reportIssue(callback: (error?: OTError, reportId?: string) => void): void;
 
     setLogLevel(level: number): void;
+
+    setProxyUrl(proxyUrl: string): void;
 
     upgradeSystemRequirements(): void;
   }
@@ -87,6 +90,7 @@ export namespace OT {
   }
 
   export type Session = OTSession.Session;
+  export type InitSessionOptions = OTSession.initSessionOptions;
   export type Event<Type, Target> = OTEvent.Event<Type, Target>;
   export type Connection  = OTConnection.Connection;
   export type Stream  = OTStream.Stream;

--- a/src/NetworkTest/types/opentok/session.ts
+++ b/src/NetworkTest/types/opentok/session.ts
@@ -93,3 +93,17 @@ export interface Session extends OTEventEmitter<{
   unpublish(publisher: Publisher): void;
   unsubscribe(subscriber: Subscriber): void;
 }
+
+export interface initSessionOptions {
+    ipWhitelist?: boolean;
+    iceConfig?: {
+      includeServers: 'all' | 'custom';
+      transportPolicy: 'all' | 'relay';
+      customServers: {
+        urls: string | string[];
+        username?: string;
+        credential?: string;
+      }[];
+    };
+    proxyUrl?: string;
+}


### PR DESCRIPTION
Hi team, this PR adds the support to the session options and Proxy Url.

- Updated `@opentok/client` version to `2.17.5`
- Added support for `setProxyUrl`
- Added support for [session init options](https://tokbox.com/developer/sdks/js/reference/OT.html#initSession)