### PR TITLE
[ECO-5336] Consider the last stats snapshot

### DIFF
--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -302,7 +302,8 @@ function checkSubscriberQuality(
 
             subscriberMOS(builder.state, subscriber, getStatsListener, resultsCallback);
 
-            mosEstimatorTimeoutId = window.setTimeout(processResults, testTimeout);
+            // We add +1 to the testTimeout value in order to consider the last stats snapshot.
+            mosEstimatorTimeoutId = window.setTimeout(processResults, testTimeout + 1);
 
             window.clearTimeout(stopTestTimeoutId);
             stopTestTimeoutId = window.setTimeout(() => {


### PR DESCRIPTION
This PR adds 1 msec to the timeout in order to allow return the last available stats snapshot.