### PR TITLE
[ECO-5337] Return video bitrate and packet loss when the video is not supported

### DIFF
--- a/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
+++ b/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
@@ -34,9 +34,6 @@ function calculateVideoScore(subscriber: OT.Subscriber, stats: OT.SubscriberStat
     return 1;
   }
 
-  const totalPackets = calculateTotalPackets('video', currentStats, lastStats);
-  const packetLoss = getPacketsLost(currentStats.video) - getPacketsLost(lastStats.video) / totalPackets;
-  const interval = currentStats.timestamp - lastStats.timestamp;
   const baseBitrate = calculateBitRate('video', currentStats, lastStats);
   const pixelCount = subscriber.stream.videoDimensions.width * subscriber.stream.videoDimensions.height;
   const targetBitrate = targetBitrateForPixelCount(pixelCount);

--- a/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
+++ b/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
@@ -120,7 +120,6 @@ export default function subscriberMOS(
          * We know that we're receiving "faulty" stats when we see a negative
          * value for bytesReceived.
          */
-        const getPacketsLost = (ts: OT.TrackStats): number => getOr(0, 'packetsLost', ts);
         if (stats.audio.bytesReceived < 0 || getOr(1, 'video.bytesReceived', stats) < 0) {
           mosState.clearInterval();
           return callback(mosState);
@@ -141,7 +140,6 @@ export default function subscriberMOS(
         mosState.videoScoresLog.push(videoScore);
         const audioScore = calculateAudioScore(subscriber, mosState.statsLog);
         mosState.audioScoresLog.push(audioScore);
-
         mosState.pruneScores();
 
         // If bandwidth has reached a steady state, end the test early

--- a/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
+++ b/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
@@ -140,6 +140,7 @@ export default function subscriberMOS(
         mosState.videoScoresLog.push(videoScore);
         const audioScore = calculateAudioScore(subscriber, mosState.statsLog);
         mosState.audioScoresLog.push(audioScore);
+
         mosState.pruneScores();
 
         // If bandwidth has reached a steady state, end the test early

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -276,8 +276,11 @@ function checkSubscriberQuality(
               const audioVideoResults: QualityTestResults = buildResults(builder);
               if (!audioOnly && !isAudioQualityAcceptable(audioVideoResults)) {
                 audioOnly = true;
+                // We don't want to lose the videoResults.
+                const videoResults = audioVideoResults.video;
                 checkSubscriberQuality(OT, session, credentials, options, onUpdate, true)
                   .then((results: QualityTestResults) => {
+                    results.video = videoResults;
                     resolve(results);
                   });
               } else {


### PR DESCRIPTION
This PR adds the video bitrate and packet loss to the final results when the video is not supported.