### PR TITLE
[ECO-2606] Fix packetsLost calculation

### DIFF
--- a/src/NetworkTest/testQuality/helpers/calculateQualityStats.ts
+++ b/src/NetworkTest/testQuality/helpers/calculateQualityStats.ts
@@ -20,8 +20,11 @@ function calculateStats(type: AV, samples: SubscriberStats[]): QualityStats[] {
 
       const packetsReceived = currStat[type].packetsReceived;
       const packetsLost = currStat[type].packetsLost;
-      const packetLossRatio = packetsLost / packetsReceived;
-
+      const totalExpectedPackets = packetsLost + packetsReceived;
+      let packetLossRatio = 0;
+      if (totalExpectedPackets > 0) {
+        packetLossRatio = packetsLost / totalExpectedPackets;
+      }
       const frameRate = type === 'video' ? { frameRate: currStat[type].frameRate } : {};
 
       qualityStats.push({ averageBitrate, packetLossRatio, ...frameRate });


### PR DESCRIPTION
**What is this PR doing?**
This PR fixes the packetsLost. The general formula should be `lost / totalPackets`, being totalPackets = lost + received.