### PR TITLE
[ECO-2606] Use audio MOS as threshold for Audio

### DIFF
--- a/src/NetworkTest/testQuality/helpers/calculateThroughput.ts
+++ b/src/NetworkTest/testQuality/helpers/calculateThroughput.ts
@@ -1,6 +1,6 @@
 import getLatestSampleWindow from './getLatestSampleWindow';
 import calculateQualityStats from './calculateQualityStats';
-import getQualityEvaluation from './getQualityEvaluation';
+import getVideoQualityEvaluation from './getVideoQualityEvaluation';
 import { AV, AverageStats, AverageStatsBase, HasAudioVideo, QualityStats } from '../types/stats';
 import config from './config';
 import MOSState from './MOSState';
@@ -23,16 +23,21 @@ function getAverageBitrateAndPlr(type: AV, statsList: QualityStats[]): AverageSt
     bitrate: sumBps / statsList.length,
     packetLossRatio: sumPlr / statsList.length,
   };
-  const { supported, reason, recommendedResolution, recommendedFrameRate } =
-    getQualityEvaluation(averageStats, type);
-  const videoStats =
-    type === 'video' ? {
-      recommendedResolution,
-      recommendedFrameRate,
-      frameRate: sumFrameRate / statsList.length,
-    } : {};
 
-  return { ...averageStats, supported, reason, ...videoStats };
+  if (type === 'video') {
+    const { supported, reason, recommendedResolution, recommendedFrameRate } =
+    getVideoQualityEvaluation(averageStats);
+
+    const videoStats =
+      type === 'video' ? {
+        recommendedResolution,
+        recommendedFrameRate,
+        frameRate: sumFrameRate / statsList.length,
+      } : {};
+    return { ...averageStats, supported, reason, ...videoStats };
+  } else {
+    return { ...averageStats };
+  }
 }
 
 export default function calculateThroughput(state: MOSState): HasAudioVideo<AverageStats> {

--- a/src/NetworkTest/testQuality/helpers/config.ts
+++ b/src/NetworkTest/testQuality/helpers/config.ts
@@ -1,6 +1,6 @@
 
-export interface AudioThreshold { bps: number; plr: number; }
-export interface VideoThreshold extends AudioThreshold { recommendedSetting: string; }
+export interface AudioThreshold { minMos: number; }
+export interface VideoThreshold { bps: number; plr: number; recommendedSetting: string; }
 
 export type QualityTestConfig = {
   getStatsInterval: number,
@@ -70,8 +70,7 @@ const config: QualityTestConfig = {
     ],
     audio: [
       {
-        bps: 25000,
-        plr: 0.05,
+        minMos: 2.4 // Should greather than 2.4 which is Fair.
       },
     ],
   },

--- a/src/NetworkTest/testQuality/helpers/getVideoQualityEvaluation.ts
+++ b/src/NetworkTest/testQuality/helpers/getVideoQualityEvaluation.ts
@@ -1,6 +1,6 @@
 import config from './config';
 import { get } from '../../util';
-import { AV, AverageStatsBase } from '../types/stats';
+import { AverageStatsBase } from '../types/stats';
 
 export interface QualityEvaluationResults{
   supported: boolean;
@@ -9,11 +9,10 @@ export interface QualityEvaluationResults{
   reason?: string;
 }
 
-export default function getQualityEvaluation(stats: AverageStatsBase, type: AV): QualityEvaluationResults {
-  const qualityThresholds = config.qualityThresholds;
+export default function getVideoQualityEvaluation(stats: AverageStatsBase): QualityEvaluationResults {
+  const thresholds = config.qualityThresholds.video;
   const bitrate = stats.bitrate;
   const packetLoss = stats.packetLossRatio;
-  const thresholds = qualityThresholds[type];
   let supported = false;
   let recommendedFrameRate : number = 30;
   let recommendedResolution : string = '';
@@ -23,14 +22,12 @@ export default function getQualityEvaluation(stats: AverageStatsBase, type: AV):
     const threshold = thresholds[i];
     if (bitrate >= threshold.bps && packetLoss <= threshold.plr) {
       supported = true;
-      if (type === 'video') {
-        recommendedSetting = get('recommendedSetting', threshold);
-        // recommendedSetting is of the form '640x480 @ 30FPS'
-        recommendedFrameRate = Number(recommendedSetting
-          .substring(recommendedSetting.indexOf('@') + 1).replace('FPS', ''));
-        recommendedResolution =
-          recommendedSetting.substring(0, recommendedSetting.indexOf('@') - 1);
-      }
+      recommendedSetting = get('recommendedSetting', threshold);
+      // recommendedSetting is of the form '640x480 @ 30FPS'
+      recommendedFrameRate = Number(recommendedSetting
+        .substring(recommendedSetting.indexOf('@') + 1).replace('FPS', ''));
+      recommendedResolution =
+        recommendedSetting.substring(0, recommendedSetting.indexOf('@') - 1);
       break;
     }
   }
@@ -43,7 +40,7 @@ export default function getQualityEvaluation(stats: AverageStatsBase, type: AV):
 
   if (!supported) {
     result.reason = config.strings.bandwidthLow;
-  } else if (supported && type === 'video') {
+  } else {
     result.recommendedFrameRate = recommendedFrameRate;
     result.recommendedResolution = recommendedResolution;
   }

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -193,6 +193,12 @@ function buildResults(builder: QualityTestResultsBuilder): QualityTestResults {
   const baseProps: (keyof AverageStats)[] = ['bitrate', 'packetLossRatio', 'supported', 'reason', 'mos'];
   builder.state.stats.audio.mos = builder.state.audioQualityScore();
   builder.state.stats.video.mos = builder.state.videoQualityScore();
+  if (builder.state.stats.audio.mos >= config.qualityThresholds.audio[0].minMos) {
+    builder.state.stats.audio.supported = true;
+  } else {
+    builder.state.stats.audio.supported = false;
+    builder.state.stats.audio.reason = config.strings.bandwidthLow;
+  }
   return {
     audio: pick(baseProps, builder.state.stats.audio),
     video: pick(baseProps.concat(['frameRate', 'recommendedResolution', 'recommendedFrameRate']),
@@ -201,10 +207,7 @@ function buildResults(builder: QualityTestResultsBuilder): QualityTestResults {
 }
 
 function isAudioQualityAcceptable(results: QualityTestResults): boolean {
-  return !!results.audio.bitrate && (results.audio.bitrate > config.qualityThresholds.audio[0].bps)
-    && (!!results.audio.packetLossRatio &&
-      (results.audio.packetLossRatio < config.qualityThresholds.audio[0].plr)
-      || results.audio.packetLossRatio === 0);
+  return !!results.audio.mos && (results.audio.mos >= config.qualityThresholds.audio[0].minMos)
 }
 
 /**


### PR DESCRIPTION
**What is this PR doing?**
We have a threshold for audio that seems to be wrong. We require to have at least 25 kpbs and a packet loss ratio less than 5%. We less than this the MOS could be 'Fair'. So it's incorrect to say "The audio is not supported" with a Fair result for MOS.
As a suggestion talking with Philip Hancke, we'll use for Audio the MOS Score. If the Mos Score is under Fair (that is, Poor or Bad) we'll say that the audio is not supported. Otherwise, it will be supported. 