### PR TITLE
[ECO-5390] Prevent negative values for packetsLossRatio

### DIFF
--- a/src/NetworkTest/testQuality/helpers/calculateQualityStats.ts
+++ b/src/NetworkTest/testQuality/helpers/calculateQualityStats.ts
@@ -22,7 +22,7 @@ function calculateStats(type: AV, samples: SubscriberStats[]): QualityStats[] {
       const packetsLost = currStat[type].packetsLost;
       const totalExpectedPackets = packetsLost + packetsReceived;
       let packetLossRatio = 0;
-      if (totalExpectedPackets > 0) {
+      if (totalExpectedPackets > 0 && packetsLost > 0) {
         packetLossRatio = packetsLost / totalExpectedPackets;
       }
       const frameRate = type === 'video' ? { frameRate: currStat[type].frameRate } : {};

--- a/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
+++ b/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
@@ -119,7 +119,10 @@ function calculateAudioScore(
   if (totalAudioPackets === 0) {
     return 1;
   }
-  const packetLossRatio = (getPacketsLost(currentStats.audio) - getPacketsLost(lastStats.audio)) / totalAudioPackets;
+  let packetLossRatio = (getPacketsLost(currentStats.audio) - getPacketsLost(lastStats.audio)) / totalAudioPackets;
+  if (packetLossRatio < 0) {
+    packetLossRatio = 0;
+  }
   return audioScore(packetLossRatio);
 }
 


### PR DESCRIPTION
**What is this PR doing?**
It add a validation to packetLossRatio calculation so that in case it's negative, we return 0.