### PR TITLE
Use roundTripTime in MS and Fix R calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-network-test-js",
-  "version": "2.4.0-beta.1",
+  "version": "2.4.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-network-test-js",
-  "version": "2.4.0-beta.1",
+  "version": "2.4.0-beta.2",
   "description": "Precall network test for applications using the OpenTok platform.",
   "main": "dist/NetworkTest/index.js",
   "types": "dist/NetworkTest/index.d.ts",

--- a/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
+++ b/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
@@ -58,8 +58,8 @@ function calculateAudioScore(
    * We can get this only using the standard getStats API. For legacy API
    * we will return 0.
    */
-  const getRoundTripTime = (): number => {
-    const DEFAULT_RTT = 150;
+  const getDelay = (): number => {
+    const DEFAULT_RTT = 150; // expressed in ms
     if (!publisherStats) {
       return DEFAULT_RTT;
     }
@@ -81,12 +81,12 @@ function calculateAudioScore(
     const a = 0; // ILBC: a=10
     const b = 19.8;
     const c = 29.7;
-    const roundTripTime = getRoundTripTime();
+    const delay = getDelay();
     /**
      * Calculate the transmission rating factor, R
      */
     const calculateR = (): number => {
-      const d = roundTripTime + LOCAL_DELAY;
+      const d = delay + LOCAL_DELAY;
       const delayImpairment = 0.024 * d + 0.11 * (d - 177.3) * h(d - 177.3);
       const equipmentImpairment = a + b * Math.log(1 + (c * packetLossRatio));
       return 93.2 - delayImpairment - equipmentImpairment;

--- a/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
+++ b/src/NetworkTest/testQuality/helpers/subscriberMOS.ts
@@ -8,7 +8,6 @@ import getPublisherRtcStatsReport from '../helpers/getPublisherRtcStatsReport';
 
 export type StatsListener = (error?: OT.OTError, stats?: OT.SubscriberStats) => void;
 
-
 const getPacketsLost = (ts: OT.TrackStats): number => getOr(0, 'packetsLost', ts);
 const getPacketsReceived = (ts: OT.TrackStats): number => getOr(0, 'packetsReceived', ts);
 const getTotalPackets = (ts: OT.TrackStats): number => getPacketsLost(ts) + getPacketsReceived(ts);


### PR DESCRIPTION
**What is this PR doing?**
1) It fixes the use of roundTripTime. We need to convertir to ms since it comes expressed in seconds from getStats. Also, regarding the original code, it needs to be divided by 2: https://github.com/opentok/gru/blob/develop/src/main/java/com/tokbox/gru/extractors/AudioScoreAlgorithm.java#L57
2) It fixes the formula for `delayImpairment` and `equipmentImpairment`. The terms separation is not correct regarding 
https://github.com/opentok/gru/blob/develop/src/main/java/com/tokbox/gru/extractors/AudioScoreAlgorithm.java#L63 and
https://github.com/opentok/gru/blob/develop/src/main/java/com/tokbox/gru/extractors/AudioScoreAlgorithm.java#L66