### PR TITLE
Removing permissions while `testQuality` is running causes a "freeze" 

### DIFF
--- a/src/NetworkTest/errors/types.ts
+++ b/src/NetworkTest/errors/types.ts
@@ -32,6 +32,7 @@ export enum ErrorNames {
   PUBLISH_TO_SESSION_NOT_CONNECTED = 'PublishToSessionNotConnectedError',
   PUBLISH_TO_SESSION_PERMISSION_OR_TIMEOUT_ERROR = 'PublishToSessionPermissionOrTimeoutError',
   PUBLISH_TO_SESSION_NETWORK_ERROR = 'PublishToSessionNetworkError',
+  MEDIA_ACCESS_REVOKED_ERROR = 'MediaAccessRevokedError',
   SUBSCRIBE_TO_SESSION_ERROR = 'SubscribeToSessionError',
   LOGGING_SERVER_CONNECTION_ERROR = 'LoggingServerConnectionError',
   QUALITY_TEST_ERROR = 'QualityTestError',

--- a/src/NetworkTest/testQuality/errors/index.ts
+++ b/src/NetworkTest/testQuality/errors/index.ts
@@ -121,6 +121,13 @@ export class PublishToSessionPermissionOrTimeoutError extends PublishToSessionEr
   }
 }
 
+export class MediaAccessRevokedError extends PublishToSessionError {
+  constructor() {
+    super('Media access was revoked during the quality test.',
+      ErrorNames.MEDIA_ACCESS_REVOKED_ERROR);
+  }
+}
+
 /**
  * Subscriber Errors
  */

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -208,6 +208,12 @@ function publishAndSubscribe(OTInstance: typeof OT, options?: NetworkTestOptions
               });
             }
           });
+
+
+          publisher.on('mediaStopped', () => {
+            disconnectAndReject(new e.MediaAccessRevokedError());
+          });
+
           publisher.on('streamCreated', (event: StreamCreatedEvent) => {
             const subscriber =
               session.subscribe(event.stream,
@@ -352,6 +358,11 @@ function checkSubscriberQuality(
                 onUpdate(updateStats);
               }
             };
+
+            publisher.on('streamDestroyed', () => {
+              clearTimeout(mosEstimatorTimeoutId);
+              disconnectAndReject(new e.MediaAccessRevokedError());
+            });
 
             const processResults = () => {
               const audioVideoResults: QualityTestResults = buildResults(builder);

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -209,7 +209,6 @@ function publishAndSubscribe(OTInstance: typeof OT, options?: NetworkTestOptions
             }
           });
 
-
           publisher.on('mediaStopped', () => {
             disconnectAndReject(new e.MediaAccessRevokedError());
           });
@@ -359,9 +358,11 @@ function checkSubscriberQuality(
               }
             };
 
-            publisher.on('streamDestroyed', () => {
-              clearTimeout(mosEstimatorTimeoutId);
-              disconnectAndReject(new e.MediaAccessRevokedError());
+            publisher.on('streamDestroyed', (event: OT.Event<'streamDestroyed', OT.Publisher>) => {
+              if ((event as any).reason === 'mediaStopped') {
+                clearTimeout(mosEstimatorTimeoutId);
+                disconnectAndReject(new e.MediaAccessRevokedError());
+              }
             });
 
             const processResults = () => {


### PR DESCRIPTION
One of our customers mentioned the following issue with the precall test flow:

* initially, grant permissions when the test is running
* while the test is running, in particular the `testQuality()` part, remove the permissions to the device
* notice that the test never completes, it happens because there is no handling of media being stopped on the publisher

To reproduce the issue, do the following with the `sample/` app in the `opentok-network-test-js`:

* Open the sample application in a supported browser (Chrome, Firefox, or Safari)
* Click the "Run Test" button on the precall screen
* Grant camera and microphone permissions when prompted by the browser
* Wait for the quality test to start (you should see "Test in progress" with a spinner)
* While the test is running (within the first 5-15 seconds):
** Click the camera/microphone icon in the browser's address bar
** Click "Reset Permissions"

Observe the issue: 
* The test freezes indefinitely
* The spinner continues to spin
* No error message is displayed
* The test never completes or fails
* No console errors are logged

To reproduce the fix, perform the same steps as above but on this branch. Notice that now the test ends and an error message is displayed. 