### PR TITLE
Fix/Add Failure Logging for testConnectivity/testQuality

### DIFF
--- a/src/NetworkTest/index.ts
+++ b/src/NetworkTest/index.ts
@@ -127,7 +127,16 @@ export default class NetworkTest {
     this.otLogging.logEvent({ action: 'testQuality', variation: 'Attempt' });
     if (updateCallback) {
       if (typeof updateCallback !== 'function' || updateCallback.length !== 1) {
-        this.otLogging.logEvent({ action: 'testQuality', variation: 'Failure' });
+        this.otLogging.logEvent({
+          action: 'testQuality',
+          variation: 'Failure',
+          payload: {
+            errorName: 'InvalidOnUpdateCallback',
+            reason: typeof updateCallback !== 'function'
+              ? 'updateCallback is not a function'
+              : 'updateCallback does not accept exactly 1 parameter',
+          },
+        });
         throw new InvalidOnUpdateCallback();
       }
     }

--- a/src/NetworkTest/testConnectivity/index.ts
+++ b/src/NetworkTest/testConnectivity/index.ts
@@ -318,6 +318,14 @@ export function testConnectivity(
 
     const onFailure = (error: Error) => {
       if (error.name === ErrorNames.PERMISSION_DENIED_ERROR) {
+        otLogging.logEvent({
+          action: 'testConnectivity',
+          variation: 'Failure',
+          payload: {
+            errorName: error.name,
+            errorMessage: error.message,
+          },
+        });
         reject(error);
         return;
       }
@@ -338,7 +346,17 @@ export function testConnectivity(
           failedTests,
           success: false,
         };
-        otLogging.logEvent({ action: 'testConnectivity', variation: 'Success' });
+        otLogging.logEvent({
+          action: 'testConnectivity',
+          variation: 'Failure',
+          payload: {
+            failedTests: failedTests.map(test => ({
+              type: test.type,
+              error: test.error.name,
+            })),
+            errorNames: errors.map(e => e.name),
+          },
+        });
         resolve(results);
       };
 

--- a/src/NetworkTest/testConnectivity/index.ts
+++ b/src/NetworkTest/testConnectivity/index.ts
@@ -352,9 +352,9 @@ export function testConnectivity(
           payload: {
             failedTests: failedTests.map(test => ({
               type: test.type,
-              error: test.error.name,
+              error: test.error.name || 'Unknown Error',
             })),
-            errorNames: errors.map(e => e.name),
+            errorNames: errors.map(e => e.name || 'Unknown Error'),
           },
         });
         resolve(results);

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -444,7 +444,14 @@ export function testQuality(
 
     const onError = (error: Error) => {
       stopTest = undefined;
-      otLogging.logEvent({ action: 'testQuality', variation: 'Failure' });
+      otLogging.logEvent({
+        action: 'testQuality',
+        variation: 'Failure',
+        payload: {
+          errorName: error.name,
+          errorMessage: error.message,
+        },
+      });
       reject(error);
     };
 


### PR DESCRIPTION
Currently, we only log `testQuality` as `Attempt`/`Success`/`Failure` but not for `testConnectivity` for which we only log `Attempt` and `Success` (in one spot, we log `Success` incorrectly as it should be a failure. I also added a `payload` field for the `testQuality` field so that we have relevant information as to why it failed. 

To reproduce the issue: 

* Checkout `develop` branch.
* Run the `sample/` app locally and do something that will cause `testConnectivity` to fail such as rejecting the access to the devices when prompted. 
* Notice that only `Attempt` and `Success` are logged for `testConnectivity` in kibana client_event logs. 

To reproduce the fix:
* Checkout this branch.
* Perform the test above.
* Notice that now in `client_event` logs you have a `Failure` in `variation` for the `action` set to `testConnectivity`. Notice that there is also a `payload` field with the relevant information about the failure. 