### PR TITLE
[PREQ-5140]: Add Connection Type to results.video

### DIFF
--- a/sample/assets/styles.css
+++ b/sample/assets/styles.css
@@ -185,7 +185,7 @@ div.prettyBox img {
   display: none;
 }
 
-#video-routingResolution {
+#video-mediaRouting {
   font-weight: 600;
   padding: 2px 8px;
   border-radius: 4px;

--- a/sample/assets/styles.css
+++ b/sample/assets/styles.css
@@ -185,6 +185,33 @@ div.prettyBox img {
   display: none;
 }
 
+#video-routingResolution {
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+  display: inline-block;
+}
+
+.routing-routed {
+  background-color: #4caf50;
+  color: white;
+}
+
+.routing-stun {
+  background-color: #ff9800;
+  color: white;
+}
+
+.routing-turn {
+  background-color: #2196f3;
+  color: white;
+}
+
+.routing-unknown {
+  background-color: #9e9e9e;
+  color: white;
+}
+
 @media screen and (max-width: 380px) {
   h1 {
     font-size: 24px;

--- a/sample/index.html
+++ b/sample/index.html
@@ -46,6 +46,9 @@
         <p>Test in progress.</p>
         <img src="assets/spinner.gif">
         <button id="stop_test">Stop test</button>
+        <div id="connection-info" style="margin-top: 10px; display: none;">
+          <p style="font-size: 14px; color: #666;">Connection type: <span id="connection-type-live" style="font-weight: 600;"></span></p>
+        </div>
       </div>
       <div>
         <div id="audio">

--- a/sample/src/js/connectivity-ui.js
+++ b/sample/src/js/connectivity-ui.js
@@ -167,12 +167,12 @@ export function displayTestQualityResults(error, results) {
   resultsEl.querySelector('#video-recommendedFrameRate').textContent =
     results.video.recommendedFrameRate ? results.video.recommendedFrameRate + ' fps' : '--';
   
-  const routingResolutionEl = resultsEl.querySelector('#video-routingResolution');
-  if (routingResolutionEl && results.video.routingResolution) {
-    routingResolutionEl.textContent = results.video.routingResolution;
-    routingResolutionEl.className = getRoutingResolutionClass(results.video.routingResolution);
-  } else if (routingResolutionEl) {
-    routingResolutionEl.textContent = '--';
+  const mediaRoutingEl = resultsEl.querySelector('#video-mediaRouting');
+  if (mediaRoutingEl && results.video.mediaRouting) {
+    mediaRoutingEl.textContent = results.video.mediaRouting;
+    mediaRoutingEl.className = getMediaRoutingClass(results.video.mediaRouting);
+  } else if (mediaRoutingEl) {
+    mediaRoutingEl.textContent = '--';
   }
   
   if (results.audio.supported) {
@@ -206,11 +206,11 @@ export function graphIntermediateStats(mediaType, stats) {
   charts[mediaType].setTitle(null, { text: chartTitle});
   prevBitsReceived[mediaType] = bitsSent;
   
-  if (mediaType === 'video' && stats.video && stats.video.routingResolution) {
-    const routingResolutionEl = document.querySelector('#video-routingResolution');
-    if (routingResolutionEl) {
-      routingResolutionEl.textContent = stats.video.routingResolution;
-      routingResolutionEl.className = getRoutingResolutionClass(stats.video.routingResolution);
+  if (mediaType === 'video' && stats.video && stats.video.mediaRouting) {
+    const mediaRoutingEl = document.querySelector('#video-mediaRouting');
+    if (mediaRoutingEl) {
+      mediaRoutingEl.textContent = stats.video.mediaRouting;
+      mediaRoutingEl.className = getMediaRoutingClass(stats.video.mediaRouting);
       
       const videoResultsEl = document.querySelector('#video .results');
       if (videoResultsEl && videoResultsEl.style.display !== 'block') {
@@ -222,20 +222,20 @@ export function graphIntermediateStats(mediaType, stats) {
     const connectionTypeLiveEl = document.getElementById('connection-type-live');
     if (connectionInfoEl && connectionTypeLiveEl) {
       connectionInfoEl.style.display = 'block';
-      connectionTypeLiveEl.textContent = stats.video.routingResolution;
-      connectionTypeLiveEl.className = getRoutingResolutionClass(stats.video.routingResolution);
+      connectionTypeLiveEl.textContent = stats.video.mediaRouting;
+      connectionTypeLiveEl.className = getMediaRoutingClass(stats.video.mediaRouting);
     }
   }
 }
 
-function getRoutingResolutionClass(routingResolution) {
-  if (routingResolution === 'Routed') {
+function getMediaRoutingClass(mediaRouting) {
+  if (mediaRouting === 'Routed') {
     return 'routing-routed';
   }
-  if (routingResolution.includes('TURN')) {
+  if (mediaRouting.includes('TURN')) {
     return 'routing-turn';
   }
-  if (routingResolution.includes('STUN')) {
+  if (mediaRouting.includes('STUN')) {
     return 'routing-stun';
   }
   return 'routing-unknown';

--- a/sample/src/js/connectivity-ui.js
+++ b/sample/src/js/connectivity-ui.js
@@ -166,6 +166,15 @@ export function displayTestQualityResults(error, results) {
     results.video.recommendedResolution || '--';
   resultsEl.querySelector('#video-recommendedFrameRate').textContent =
     results.video.recommendedFrameRate ? results.video.recommendedFrameRate + ' fps' : '--';
+  
+  const routingResolutionEl = resultsEl.querySelector('#video-routingResolution');
+  if (routingResolutionEl && results.video.routingResolution) {
+    routingResolutionEl.textContent = results.video.routingResolution;
+    routingResolutionEl.className = getRoutingResolutionClass(results.video.routingResolution);
+  } else if (routingResolutionEl) {
+    routingResolutionEl.textContent = '--';
+  }
+  
   if (results.audio.supported) {
     if (results.video.supported || audioOnlyTest) {
       statusIconEl.src = 'assets/icon_pass.svg';
@@ -196,4 +205,38 @@ export function graphIntermediateStats(mediaType, stats) {
    'Bitrate over ' + resultCount[mediaType] + 'sec';
   charts[mediaType].setTitle(null, { text: chartTitle});
   prevBitsReceived[mediaType] = bitsSent;
+  
+  if (mediaType === 'video' && stats.video && stats.video.routingResolution) {
+    const routingResolutionEl = document.querySelector('#video-routingResolution');
+    if (routingResolutionEl) {
+      routingResolutionEl.textContent = stats.video.routingResolution;
+      routingResolutionEl.className = getRoutingResolutionClass(stats.video.routingResolution);
+      
+      const videoResultsEl = document.querySelector('#video .results');
+      if (videoResultsEl && videoResultsEl.style.display !== 'block') {
+        videoResultsEl.style.display = 'block';
+      }
+    }
+    
+    const connectionInfoEl = document.getElementById('connection-info');
+    const connectionTypeLiveEl = document.getElementById('connection-type-live');
+    if (connectionInfoEl && connectionTypeLiveEl) {
+      connectionInfoEl.style.display = 'block';
+      connectionTypeLiveEl.textContent = stats.video.routingResolution;
+      connectionTypeLiveEl.className = getRoutingResolutionClass(stats.video.routingResolution);
+    }
+  }
+}
+
+function getRoutingResolutionClass(routingResolution) {
+  if (routingResolution === 'Routed') {
+    return 'routing-routed';
+  }
+  if (routingResolution.includes('TURN')) {
+    return 'routing-turn';
+  }
+  if (routingResolution.includes('STUN')) {
+    return 'routing-stun';
+  }
+  return 'routing-unknown';
 }

--- a/src/NetworkTest/testQuality/helpers/getPublisherRtcStatsReport.ts
+++ b/src/NetworkTest/testQuality/helpers/getPublisherRtcStatsReport.ts
@@ -1,5 +1,5 @@
-import { PublisherStats, RoutingResolution } from '../../types/publisher';
-import { RTCIceCandidateStats } from '../../types/rtcStats';
+import { PublisherStats } from '../../types/publisher';
+import { RTCIceCandidateStats, MediaRouting } from '../../types/rtcStats';
 
 export interface PreviousStreamStats {
   [ssrc: number]: {
@@ -57,10 +57,10 @@ const calculateVideoBitrate = (
   return Math.round((byteSent * 8) / (1000 * timeDiff)); // Convert to kbit per second
 };
 
-const determineRoutingResolution = (
+const determineMediaRouting = (
   localCandidate: RTCIceCandidateStats | null,
   remoteCandidate: RTCIceCandidateStats | null,
-): RoutingResolution => {
+): MediaRouting => {
   if (!localCandidate || !remoteCandidate) {
     return 'Unknown';
   }
@@ -157,6 +157,7 @@ const extractPublisherStats = (
 
   const { videoStats, audioStats } = extractOutboundRtpStats(outboundRtpStats, previousStats);
 
+  const mediaRouting = determineMediaRouting(localCandidate, remoteCandidate);
   const availableOutgoingBitrate = iceCandidatePairStats?.availableOutgoingBitrate || -1;
   const currentRoundTripTime = iceCandidatePairStats?.currentRoundTripTime || -1;
   const videoKbsSent = videoStats.reduce((sum, stats) => sum + stats.kbs, 0);
@@ -164,7 +165,6 @@ const extractPublisherStats = (
   const simulcastEnabled = videoStats.length > 1;
   const transportProtocol = localCandidate?.protocol || 'N/A';
   const timestamp = localCandidate?.timestamp || 0;
-  const routingResolution = determineRoutingResolution(localCandidate, remoteCandidate);
 
   return {
     videoStats,
@@ -176,6 +176,6 @@ const extractPublisherStats = (
     transportProtocol,
     currentRoundTripTime,
     timestamp,
-    routingResolution,
+    mediaRouting,
   };
 };

--- a/src/NetworkTest/testQuality/helpers/getPublisherRtcStatsReport.ts
+++ b/src/NetworkTest/testQuality/helpers/getPublisherRtcStatsReport.ts
@@ -77,32 +77,18 @@ const determineRoutingResolution = (
     return 'Routed';
   }
 
-  if (remoteType === 'relay') {
-    if (protocol === 'tcp') {
-      return 'Relayed (TURN/TLS)';
-    }
-    return 'Relayed (TURN/UDP)';
-  }
+  const isTcp = protocol === 'tcp';
 
-  if (localType === 'relay') {
-    if (protocol === 'tcp') {
-      return 'Relayed (TURN/TLS)';
-    }
-    return 'Relayed (TURN/UDP)';
+  if (localType === 'relay' || remoteType === 'relay') {
+    return isTcp ? 'Relayed (TURN/TLS)' : 'Relayed (TURN/UDP)';
   }
 
   if (localType === 'srflx' || remoteType === 'srflx') {
-    if (protocol === 'tcp') {
-      return 'Relayed (STUN/TLS)';
-    }
-    return 'Relayed (STUN/UDP)';
+    return isTcp ? 'Relayed (STUN/TLS)' : 'Relayed (STUN/UDP)';
   }
 
   if (localType === 'prflx' || remoteType === 'prflx') {
-    if (protocol === 'tcp') {
-      return 'Relayed (STUN/TLS)';
-    }
-    return 'Relayed (STUN/UDP)';
+    return isTcp ? 'Relayed (STUN/TLS)' : 'Relayed (STUN/UDP)';
   }
   return 'Unknown';
 };

--- a/src/NetworkTest/testQuality/helpers/getPublisherRtcStatsReport.ts
+++ b/src/NetworkTest/testQuality/helpers/getPublisherRtcStatsReport.ts
@@ -57,6 +57,56 @@ const calculateVideoBitrate = (
   return Math.round((byteSent * 8) / (1000 * timeDiff)); // Convert to kbit per second
 };
 
+const determineRoutingResolution = (
+  localCandidate: RTCIceCandidateStats | null,
+  remoteCandidate: RTCIceCandidateStats | null,
+): string => {
+  if (!localCandidate || !remoteCandidate) {
+    return 'Unknown';
+  }
+
+  const localType = localCandidate.candidateType;
+  const remoteType = remoteCandidate.candidateType;
+  const protocol = (localCandidate.protocol || '').toLowerCase();
+
+  if (localType === 'host' && remoteType === 'host') {
+    return 'Routed';
+  }
+
+  if ((localType === 'prflx' || localType === 'host') && remoteType === 'host') {
+    return 'Routed';
+  }
+
+  if (remoteType === 'relay') {
+    if (protocol === 'tcp') {
+      return 'Relayed (TURN/TLS)';
+    }
+    return 'Relayed (TURN/UDP)';
+  }
+
+  if (localType === 'relay') {
+    if (protocol === 'tcp') {
+      return 'Relayed (TURN/TLS)';
+    }
+    return 'Relayed (TURN/UDP)';
+  }
+
+  if (localType === 'srflx' || remoteType === 'srflx') {
+    if (protocol === 'tcp') {
+      return 'Relayed (STUN/TLS)';
+    }
+    return 'Relayed (STUN/UDP)';
+  }
+
+  if (localType === 'prflx' || remoteType === 'prflx') {
+    if (protocol === 'tcp') {
+      return 'Relayed (STUN/TLS)';
+    }
+    return 'Relayed (STUN/UDP)';
+  }
+  return 'Unknown';
+};
+
 const extractOutboundRtpStats = (
   outboundRtpStats: (RTCOutboundRtpStreamStats & {
     mediaType?: 'video' | 'audio';
@@ -116,7 +166,8 @@ const extractPublisherStats = (
     return rtcStatsArray.find(stats => stats.type === type && stats.id === id) as RTCIceCandidateStats | null;
   };
 
-  const localCandidate = findCandidateById('local-candidate', iceCandidatePairStats.localCandidateId);
+  const localCandidate = findCandidateById('local-candidate', iceCandidatePairStats?.localCandidateId);
+  const remoteCandidate = findCandidateById('remote-candidate', iceCandidatePairStats?.remoteCandidateId);
 
   const { videoStats, audioStats } = extractOutboundRtpStats(outboundRtpStats, previousStats);
 
@@ -127,6 +178,7 @@ const extractPublisherStats = (
   const simulcastEnabled = videoStats.length > 1;
   const transportProtocol = localCandidate?.protocol || 'N/A';
   const timestamp = localCandidate?.timestamp || 0;
+  const routingResolution = determineRoutingResolution(localCandidate, remoteCandidate);
 
   return {
     videoStats,
@@ -138,5 +190,6 @@ const extractPublisherStats = (
     transportProtocol,
     currentRoundTripTime,
     timestamp,
+    routingResolution,
   };
 };

--- a/src/NetworkTest/testQuality/helpers/getPublisherRtcStatsReport.ts
+++ b/src/NetworkTest/testQuality/helpers/getPublisherRtcStatsReport.ts
@@ -1,4 +1,4 @@
-import { PublisherStats } from '../../types/publisher';
+import { PublisherStats, RoutingResolution } from '../../types/publisher';
 import { RTCIceCandidateStats } from '../../types/rtcStats';
 
 export interface PreviousStreamStats {
@@ -60,7 +60,7 @@ const calculateVideoBitrate = (
 const determineRoutingResolution = (
   localCandidate: RTCIceCandidateStats | null,
   remoteCandidate: RTCIceCandidateStats | null,
-): string => {
+): RoutingResolution => {
   if (!localCandidate || !remoteCandidate) {
     return 'Unknown';
   }

--- a/src/NetworkTest/testQuality/helpers/getUpdateCallbackStats.ts
+++ b/src/NetworkTest/testQuality/helpers/getUpdateCallbackStats.ts
@@ -15,7 +15,7 @@ const getUpdateCallbackStats = (
     packetsReceived: audioTrackStats.packetsReceived,
   };
 
-  let videoCallbackStats: CallbackTrackStats & { frameRate: number } | null = null;
+  let videoCallbackStats: CallbackTrackStats & { frameRate: number; routingResolution?: string } | null = null;
 
   if (phase === 'audio-video') {
     videoCallbackStats = {
@@ -24,6 +24,7 @@ const getUpdateCallbackStats = (
       packetsLost: videoTrackStats?.packetsLost || 0,
       packetsReceived: videoTrackStats?.packetsReceived || 0,
       frameRate: videoTrackStats?.frameRate || 0,
+      routingResolution: publisherStats.routingResolution,
     };
   }
 

--- a/src/NetworkTest/testQuality/helpers/getUpdateCallbackStats.ts
+++ b/src/NetworkTest/testQuality/helpers/getUpdateCallbackStats.ts
@@ -15,7 +15,7 @@ const getUpdateCallbackStats = (
     packetsReceived: audioTrackStats.packetsReceived,
   };
 
-  let videoCallbackStats: CallbackTrackStats & { frameRate: number; routingResolution?: string } | null = null;
+  let videoCallbackStats: CallbackTrackStats & { frameRate: number; mediaRouting?: string } | null = null;
 
   if (phase === 'audio-video') {
     videoCallbackStats = {
@@ -24,7 +24,7 @@ const getUpdateCallbackStats = (
       packetsLost: videoTrackStats?.packetsLost || 0,
       packetsReceived: videoTrackStats?.packetsReceived || 0,
       frameRate: videoTrackStats?.frameRate || 0,
-      routingResolution: publisherStats.routingResolution,
+      mediaRouting: publisherStats.mediaRouting,
     };
   }
 

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -249,10 +249,16 @@ function buildResults(builder: QualityTestResultsBuilder): QualityTestResults {
     builder.state.stats.audio.supported = false;
     builder.state.stats.audio.reason = config.strings.bandwidthLow;
   }
+
+  const lastPublisherStats = builder.state.getLastPublisherStats();
+  if (lastPublisherStats && lastPublisherStats.routingResolution) {
+    builder.state.stats.video.routingResolution = lastPublisherStats.routingResolution;
+  }
+
   return {
     audio: pick(baseProps, builder.state.stats.audio),
     video: pick(baseProps.concat([
-      'frameRate', 'qualityLimitationReason', 'recommendedResolution', 'recommendedFrameRate',
+      'frameRate', 'qualityLimitationReason', 'recommendedResolution', 'recommendedFrameRate', 'routingResolution',
     ]),
     builder.state.stats.video),
   };

--- a/src/NetworkTest/testQuality/index.ts
+++ b/src/NetworkTest/testQuality/index.ts
@@ -256,14 +256,14 @@ function buildResults(builder: QualityTestResultsBuilder): QualityTestResults {
   }
 
   const lastPublisherStats = builder.state.getLastPublisherStats();
-  if (lastPublisherStats && lastPublisherStats.routingResolution) {
-    builder.state.stats.video.routingResolution = lastPublisherStats.routingResolution;
+  if (lastPublisherStats && lastPublisherStats.mediaRouting) {
+    builder.state.stats.video.mediaRouting = lastPublisherStats.mediaRouting;
   }
 
   return {
     audio: pick(baseProps, builder.state.stats.audio),
     video: pick(baseProps.concat([
-      'frameRate', 'qualityLimitationReason', 'recommendedResolution', 'recommendedFrameRate', 'routingResolution',
+      'frameRate', 'qualityLimitationReason', 'recommendedResolution', 'recommendedFrameRate', 'mediaRouting',
     ]),
     builder.state.stats.video),
   };

--- a/src/NetworkTest/testQuality/types/stats.ts
+++ b/src/NetworkTest/testQuality/types/stats.ts
@@ -32,7 +32,7 @@ export interface AverageStats {
   recommendedFrameRate?: number;
   recommendedResolution?: string;
   mos?: number;
-  routingResolution?: string;
+  mediaRouting?: string;
 }
 
 export interface AverageStatsBase {

--- a/src/NetworkTest/testQuality/types/stats.ts
+++ b/src/NetworkTest/testQuality/types/stats.ts
@@ -32,6 +32,7 @@ export interface AverageStats {
   recommendedFrameRate?: number;
   recommendedResolution?: string;
   mos?: number;
+  routingResolution?: string;
 }
 
 export interface AverageStatsBase {

--- a/src/NetworkTest/types/callbacks.ts
+++ b/src/NetworkTest/types/callbacks.ts
@@ -2,7 +2,7 @@
 export type UpdateCallback<A> = (stats: UpdateCallbackStats) => void;
 export type UpdateCallbackStats = {
   audio: CallbackTrackStats;
-  video: CallbackTrackStats & { frameRate: number; routingResolution?: string };
+  video: CallbackTrackStats & { frameRate: number; mediaRouting?: string };
   timestamp: number;
   phase: string;
 };

--- a/src/NetworkTest/types/callbacks.ts
+++ b/src/NetworkTest/types/callbacks.ts
@@ -2,7 +2,7 @@
 export type UpdateCallback<A> = (stats: UpdateCallbackStats) => void;
 export type UpdateCallbackStats = {
   audio: CallbackTrackStats;
-  video: CallbackTrackStats & { frameRate: number };
+  video: CallbackTrackStats & { frameRate: number; routingResolution?: string };
   timestamp: number;
   phase: string;
 };

--- a/src/NetworkTest/types/publisher.ts
+++ b/src/NetworkTest/types/publisher.ts
@@ -17,6 +17,14 @@ export interface AudioStats {
   currentTimestamp: number;
 }
 
+export type RoutingResolution =
+  | 'Routed'
+  | 'Relayed (TURN/TLS)'
+  | 'Relayed (TURN/UDP)'
+  | 'Relayed (STUN/TLS)'
+  | 'Relayed (STUN/UDP)'
+  | 'Unknown';
+
 export interface PublisherStats {
   videoStats: VideoStats[];
   audioStats: AudioStats[];
@@ -27,5 +35,5 @@ export interface PublisherStats {
   transportProtocol: string;
   currentRoundTripTime: number;
   timestamp: number;
-  routingResolution: string;
+  routingResolution: RoutingResolution;
 }

--- a/src/NetworkTest/types/publisher.ts
+++ b/src/NetworkTest/types/publisher.ts
@@ -17,14 +17,6 @@ export interface AudioStats {
   currentTimestamp: number;
 }
 
-export type RoutingResolution =
-  | 'Routed'
-  | 'Relayed (TURN/TLS)'
-  | 'Relayed (TURN/UDP)'
-  | 'Relayed (STUN/TLS)'
-  | 'Relayed (STUN/UDP)'
-  | 'Unknown';
-
 export interface PublisherStats {
   videoStats: VideoStats[];
   audioStats: AudioStats[];
@@ -35,5 +27,5 @@ export interface PublisherStats {
   transportProtocol: string;
   currentRoundTripTime: number;
   timestamp: number;
-  routingResolution: RoutingResolution;
+  mediaRouting?: string;
 }

--- a/src/NetworkTest/types/publisher.ts
+++ b/src/NetworkTest/types/publisher.ts
@@ -27,4 +27,5 @@ export interface PublisherStats {
   transportProtocol: string;
   currentRoundTripTime: number;
   timestamp: number;
+  routingResolution: string;
 }

--- a/src/NetworkTest/types/rtcStats.ts
+++ b/src/NetworkTest/types/rtcStats.ts
@@ -1,3 +1,11 @@
+export type MediaRouting =
+  | 'Routed'
+  | 'Relayed (TURN/TLS)'
+  | 'Relayed (TURN/UDP)'
+  | 'Relayed (STUN/TLS)'
+  | 'Relayed (STUN/UDP)'
+  | 'Unknown';
+
 export interface RTCIceCandidateStats extends RTCStats {
   address: string;
   candidateType: string;
@@ -11,4 +19,5 @@ export interface RTCIceCandidateStats extends RTCStats {
   tcpType: string;
   transportId: string;
   usernameFragment: string;
+  mediaRouting?: MediaRouting;
 }


### PR DESCRIPTION
Some customers would like to know the connection type during the pre-call test so that they don't need to check it via inspector tool. 

This introduces the `results.video.routingResolution` field that they can check to see what kind of connection do they currently have. 

To check that this works:
* Checkout this branch.
* Run the test locally via the sample app and notice the `Connection Type:` having a value as the test quality is in progress. 