### PR TITLE
[VIDECO-11418] Reject on failure instead of resolve in opentok-network-test

### DIFF
--- a/sample/src/js/index.ts
+++ b/sample/src/js/index.ts
@@ -2,6 +2,7 @@ import NetworkTest, { ErrorNames } from 'opentok-network-test-js';
 import createChart from './chart.js';
 import * as ConnectivityUI from './connectivity-ui.js';
 import config from './config.js';
+import { ConnectivityError, FailureCase } from './types.js';
 declare const OT: any;
 let sessionInfo = config;
 let otNetworkTest : NetworkTest;
@@ -64,10 +65,10 @@ function startTest() {
             ConnectivityUI.displayTestConnectivityResults(results);
             return testQuality();
         })
-        .catch(error => {
-            const hasPermissionError = error.failedTests?.some(
-                (test: any) => test.error?.name === ErrorNames.PERMISSION_DENIED_ERROR
-            );
+        .catch((error: ConnectivityError) => {
+        const hasPermissionError = error.failedTests?.some(
+            (test: FailureCase) => test.error?.name === ErrorNames.PERMISSION_DENIED_ERROR
+        );
             
             if (hasPermissionError) {
                 displayPermissionDeniedError();

--- a/sample/src/js/index.ts
+++ b/sample/src/js/index.ts
@@ -58,16 +58,21 @@ function startTest() {
     };
 
     otNetworkTest = new NetworkTest(OT, sessionInfo, options);
+
     otNetworkTest.testConnectivity()
-        .then(results => ConnectivityUI.displayTestConnectivityResults(results))
-        .then(testQuality)
+        .then(results => {
+            ConnectivityUI.displayTestConnectivityResults(results);
+            return testQuality();
+        })
         .catch(error => {
-            // Handle permission errors - show message and retry button
-            if (error.name === ErrorNames.PERMISSION_DENIED_ERROR) {
+            const hasPermissionError = error.failedTests?.some(
+                (test: any) => test.error?.name === ErrorNames.PERMISSION_DENIED_ERROR
+            );
+            
+            if (hasPermissionError) {
                 displayPermissionDeniedError();
             } else {
-                // Handle other errors - show failure message and retry button
-                ConnectivityUI.displayTestConnectivityResults({ success: false, failedTests: [] });
+                ConnectivityUI.displayTestConnectivityResults(error);
                 ConnectivityUI.showRetryButton();
             }
             

--- a/sample/src/js/types.ts
+++ b/sample/src/js/types.ts
@@ -1,0 +1,11 @@
+export type FailureCase = {
+    error?: {
+        name: string;
+        message?: string;
+    };
+    type?: string;
+};
+
+export type ConnectivityError = {
+    failedTests?: FailureCase[];
+};

--- a/src/NetworkTest/testConnectivity/index.ts
+++ b/src/NetworkTest/testConnectivity/index.ts
@@ -317,19 +317,6 @@ export function testConnectivity(
     };
 
     const onFailure = (error: Error) => {
-      if (error.name === ErrorNames.PERMISSION_DENIED_ERROR) {
-        otLogging.logEvent({
-          action: 'testConnectivity',
-          variation: 'Failure',
-          payload: {
-            errorName: error.name,
-            errorMessage: error.message,
-          },
-        });
-        reject(error);
-        return;
-      }
-
       const handleResults = (...errors: e.ConnectivityError[]) => {
         /**
          * If we have a messaging server failure, we will also fail the media
@@ -357,7 +344,7 @@ export function testConnectivity(
             errorNames: errors.map(e => e.name || 'Unknown Error'),
           },
         });
-        resolve(results);
+        reject(results);
       };
 
       /**


### PR DESCRIPTION
Currently, there is an odd behavior where we `resolve` as a success when in reality the tests have failed. This PR addresses that by `reject`-ing instead. 